### PR TITLE
支持黑名单列表

### DIFF
--- a/fuo_qqmusic/api.py
+++ b/fuo_qqmusic/api.py
@@ -723,145 +723,80 @@ class API(object):
         song = 3
         _style_unsupported = 4 # TODO: 这是什么？似乎是不喜欢的风格列表，不确定，暂时不支持
 
-    def get_dislike_list(self, page=1, type=DislikeListType.song, last_id=0):
-        uin = self._uin
-
-        data = {
-            "comm": {
-                "g_tk": int(self.get_token_from_cookies()),  # NOTE: 需要是整数，下同
-                "uin": int(uin),  # NOTE: 需要是整数，下同
-                "format": "json",
-                "inCharset": "utf-8",
-                "outCharset": "utf-8",
-                "notice": 0,
-                "platform": "h5",
-            },
+    def get_dislike_list(self, page=1, type_=DislikeListType.song, last_id=0):
+        payload = {
             "req_0": {
                 "module": "music.feedback.FeedbackBlack",
                 "method": "GetDislikeList",
                 "param": {
-                    "Cmd": type.value,
+                    "Cmd": type_.value,
                     "Page": page,
-                    "SongLastid": last_id if type == API.DislikeListType.song else 0,
+                    "SongLastid": last_id if type_ == API.DislikeListType.song else 0,
                     "SingersLastid": (
-                        last_id if type == API.DislikeListType.singer else 0
+                        last_id if type_ == API.DislikeListType.singer else 0
                     ),
                 },
             },
         }
-        data_str = json.dumps(data, ensure_ascii=False)
-        params = {
-            "_": int(round(time.time() * 1000)),
-            "sign": _get_sign(data_str),
-            "_webcgikey": "GetDislikeList",
-        }
-
-        url = "https://u6.y.qq.com/cgi-bin/musics.fcg"
-        resp = requests.post(url, params=params,
-            data=data_str, headers=self._headers, cookies=self._cookies)
-        js = resp.json()
-        CodeShouldBe0.check(js)
-
-        if type == API.DislikeListType.song:
+        js = self.rpc(payload)
+        if type_ == API.DislikeListType.song:
             return js["req_0"]["data"]["Songs"]
-        elif type == API.DislikeListType.singer:
+        elif type_ == API.DislikeListType.singer:
             return js["req_0"]["data"]["Singers"]
         else:
-            raise QQIOError(f"Unknown dislike list type: {type}")
+            raise QQIOError(f"Unknown dislike list type: {type_}")
 
-    def add_to_dislike_list(self, items, type=DislikeListType.song):
-        uin = self._uin
-
+    def add_to_dislike_list(self, items, type_=DislikeListType.song):
         req_param = {
             "Singers": [],
             "Songs": [],
             "Styles": [],
             "OnlyAdd": 1,
         }
-        if type == API.DislikeListType.song:
+        if type_ == API.DislikeListType.song:
             req_param["Songs"] = items
-        elif type == API.DislikeListType.singer:
+        elif type_ == API.DislikeListType.singer:
             req_param["Singers"] = items
         else:
-            raise QQIOError(f"Unknown dislike list type: {type}")
+            raise QQIOError(f"Unknown dislike list type: {type_}")
 
-        data = {
-            "comm": {
-                "g_tk": int(self.get_token_from_cookies()),
-                "uin": int(uin),
-                "format": "json",
-                "inCharset": "utf-8",
-                "outCharset": "utf-8",
-                "notice": 0,
-                "platform": "h5",
-                "needNewCode": 1,
-                "ct": 23,
-                "cv": 0,
-            },
-            "req_0": {
-                "module": "music.feedback.FeedbackBlack",
-                "method": "AddDislike",
-                "param": req_param,
-            },
+        payload = {
+             "req_0": {
+                 "module": "music.feedback.FeedbackBlack",
+                 "method": "AddDislike",
+                 "param": req_param,
+             },
         }
-        data_str = json.dumps(data, ensure_ascii=False)
-        params = {
-            "_": int(round(time.time() * 1000)),
-            "sign": _get_sign(data_str),
-            "_webcgikey": "AddDislike",
-        }
+        js = self.rpc(payload)
+        # Response example, {'code': 0, 'data': {'Retcode': 0, 'Msg': '', 'Token': ''}}
+        CodeShouldBe0.check(js['req_0'])
+        return js['req_0']['data']
 
-        url = "https://u6.y.qq.com/cgi-bin/musics.fcg"
-        resp = requests.post(url, params=params,
-            data=data_str, headers=self._headers, cookies=self._cookies)
-        js = resp.json()
-        CodeShouldBe0.check(js)
-
-    def remove_from_dislike_list(self, items, type=DislikeListType.song):
-        uin = self._uin
-
+    def remove_from_dislike_list(self, items, type_=DislikeListType.song):
         req_param = {
             "Singers": [],
             "Songs": [],
             "Styles": [],
             "OnlyAdd": 0,
         }
-        if type == API.DislikeListType.song:
+        if type_ == API.DislikeListType.song:
             req_param["Songs"] = items
-        elif type == API.DislikeListType.singer:
+        elif type_ == API.DislikeListType.singer:
             req_param["Singers"] = items
         else:
-            raise QQIOError(f"Unknown dislike list type: {type}")
+            raise QQIOError(f"Unknown dislike list type: {type_}")
 
-        data = {
-            "comm": {
-                "g_tk": int(self.get_token_from_cookies()),
-                "uin": int(uin),
-                "format": "json",
-                "inCharset": "utf-8",
-                "outCharset": "utf-8",
-                "notice": 0,
-                "platform": "h5",
-                "needNewCode": 1,
-            },
+        payload = {
             "req_0": {
                 "module": "music.feedback.FeedbackBlack",
                 "method": "CancelDislike",
                 "param": req_param,
             },
         }
-        data_str = json.dumps(data, ensure_ascii=False)
-        params = {
-            "_": int(round(time.time() * 1000)),
-            "sign": _get_sign(data_str),
-            "_webcgikey": "CancelDislike",
-        }
-
-        url = "https://u6.y.qq.com/cgi-bin/musics.fcg"
-        resp = requests.post(url, params=params,
-            data=data_str, headers=self._headers, cookies=self._cookies)
-        js = resp.json()
+        js = self.rpc(payload)
         CodeShouldBe0.check(js)
+        CodeShouldBe0.check(js['req_0'])
+        return js['req_0']['data']
 
 
 api = API()

--- a/fuo_qqmusic/provider.py
+++ b/fuo_qqmusic/provider.py
@@ -417,6 +417,23 @@ class QQProvider(AbstractProvider, ProviderV2):
         data_songs = self.api.song_similar(int(song.identifier))
         return [_deserialize(data_song, QQSongSchema) for data_song in data_songs]
 
+    def get_dislike_list(self, page=1, type=API.DislikeListType.song, last_id=0):
+        items = self.api.get_dislike_list(page, type, last_id)
+        if type == API.DislikeListType.song:
+            return [_deserialize(item, DislikeListSongSchema) for item in items]
+        elif type == API.DislikeListType.singer:
+            return [_deserialize(item, DislikeListSingerSchema) for item in items]
+        else:
+            raise QQIOError(f"Unknown dislike list type: {type}")
+
+    def add_to_dislike_list(self, items, type=API.DislikeListType.song):
+        # TODO: convert items from XXXModel to dict
+        self.api.add_to_dislike_list(items, type)
+
+    def remove_from_dislike_list(self, items, type=API.DislikeListType.song):
+        # TODO: convert items from XXXModel to dict
+        self.api.remove_from_dislike_list(items, type)
+
 
 def _deserialize(data, schema_cls):
     schema = schema_cls()
@@ -493,4 +510,6 @@ from .schemas import (  # noqa
     SearchArtistSchema,
     SearchPlaylistSchema,
     SearchMVSchema,
+    DislikeListSongSchema,
+    DislikeListSingerSchema,
 )  # noqa

--- a/fuo_qqmusic/provider.py
+++ b/fuo_qqmusic/provider.py
@@ -427,11 +427,11 @@ class QQProvider(AbstractProvider, ProviderV2):
             raise QQIOError(f"Unknown dislike list type: {type}")
 
     def add_to_dislike_list(self, items, type=API.DislikeListType.song):
-        # TODO: convert items from XXXModel to dict
+        # TODO: convert items from list[XXXModel] to list[dict]
         self.api.add_to_dislike_list(items, type)
 
     def remove_from_dislike_list(self, items, type=API.DislikeListType.song):
-        # TODO: convert items from XXXModel to dict
+        # TODO: convert items from list[XXXModel] to list[dict]
         self.api.remove_from_dislike_list(items, type)
 
 

--- a/fuo_qqmusic/provider.py
+++ b/fuo_qqmusic/provider.py
@@ -23,12 +23,17 @@ from feeluown.library import (
     SupportsPlaylistGet,
     SupportsPlaylistSongsReader,
     SupportsRecACollectionOfSongs,
+    SupportsCurrentUserDislikeSongsReader,
+    SupportsCurrentUserDislikeAddSong,
+    SupportsCurrentUserDislikeRemoveSong,
+    SupportsCurrentUserChanged,
     SimpleSearchResult,
     SearchType,
     ModelType,
     UserModel,
 )
 from feeluown.media import Media, Quality
+from feeluown.utils.dispatch import Signal
 from feeluown.utils.reader import create_reader, SequentialReader
 from .api import API
 from .login import read_cookies
@@ -53,6 +58,9 @@ class Supports(
     SupportsPlaylistSongsReader,
     SupportsRecACollectionOfSongs,
     SupportsAlbumSongsReader,
+    SupportsCurrentUserDislikeSongsReader,
+    SupportsCurrentUserDislikeAddSong,
+    SupportsCurrentUserDislikeRemoveSong,
     Protocol,
 ):
     pass
@@ -70,6 +78,7 @@ class QQProvider(AbstractProvider, ProviderV2):
     def __init__(self):
         super().__init__()
         self.api = API()
+        self.current_user_changed = Signal()
 
     def _(self) -> Supports:
         return self
@@ -89,6 +98,7 @@ class QQProvider(AbstractProvider, ProviderV2):
             self.auth(user)
         else:
             logger.info(f'Auto login failed: {err}')
+        self.current_user_changed.emit(user)
 
     def try_get_user_from_cookies(self, cookies) -> Tuple[Optional[UserModel], str]:
         if not cookies:  # is None or empty
@@ -417,22 +427,34 @@ class QQProvider(AbstractProvider, ProviderV2):
         data_songs = self.api.song_similar(int(song.identifier))
         return [_deserialize(data_song, QQSongSchema) for data_song in data_songs]
 
-    def get_dislike_list(self, page=1, type=API.DislikeListType.song, last_id=0):
-        items = self.api.get_dislike_list(page, type, last_id)
-        if type == API.DislikeListType.song:
-            return [_deserialize(item, DislikeListSongSchema) for item in items]
-        elif type == API.DislikeListType.singer:
-            return [_deserialize(item, DislikeListSingerSchema) for item in items]
-        else:
-            raise QQIOError(f"Unknown dislike list type: {type}")
+    def current_user_dislike_create_songs_rd(self):
+        user = self.get_current_user()
+        if user is None:
+            return create_reader([])
+        # FIXME: 如果用户的黑名单歌曲数量较多的话，这样处理则是不够的
+        items = self.api.get_dislike_list(1, API.DislikeListType.song, 0)
+        songs = []
+        for item in items:
+            name = item['Name']
+            title, artists_name = name.split(' - ')
+            song = BriefSongModel(
+                source=SOURCE,
+                identifier=item['ID'],
+                title=title,
+                artists_name=artists_name,
+            )
+            songs.append(song)
+        return create_reader(songs)
 
-    def add_to_dislike_list(self, items, type=API.DislikeListType.song):
-        # TODO: convert items from list[XXXModel] to list[dict]
-        self.api.add_to_dislike_list(items, type)
+    def current_user_dislike_add_song(self, song):
+        items = [{'ID': song.identifier}]
+        js = self.api.add_to_dislike_list(items, API.DislikeListType.song)
+        return js.get('Retcode') == 0
 
-    def remove_from_dislike_list(self, items, type=API.DislikeListType.song):
-        # TODO: convert items from list[XXXModel] to list[dict]
-        self.api.remove_from_dislike_list(items, type)
+    def current_user_dislike_remove_song(self, song):
+        items = [{'ID': song.identifier}]
+        js = self.api.remove_from_dislike_list(items, API.DislikeListType.song)
+        return js.get('Retcode') == 0
 
 
 def _deserialize(data, schema_cls):

--- a/fuo_qqmusic/provider.py
+++ b/fuo_qqmusic/provider.py
@@ -532,6 +532,4 @@ from .schemas import (  # noqa
     SearchArtistSchema,
     SearchPlaylistSchema,
     SearchMVSchema,
-    DislikeListSongSchema,
-    DislikeListSingerSchema,
 )  # noqa

--- a/fuo_qqmusic/schemas.py
+++ b/fuo_qqmusic/schemas.py
@@ -357,3 +357,34 @@ class SearchMVSchema(Schema):
     @post_load
     def create_model(self, data, **kwargs):
         return create_model(VideoModel, data)
+
+class DislikeListSongSchema(Schema):
+    """
+    不喜欢列表（下称“黑名单”）中的一首歌曲。
+    可选字段在 API 返回值中总是提供，但增删列表时无需提供这些字段。
+    """
+    identifier = fields.Str(data_key="ID", required=True)
+    title = fields.Str(data_key="Name", required=True)
+    cover = fields.Str(data_key="Img", required=False)
+    id_type = fields.Int(data_key="IdType", required=True) # 歌曲 identifier 的类型，一般填 0 即可
+    add_time = fields.Int(data_key="Time", required=False)
+
+    @post_load
+    def create_model(self, data, **kwargs):
+        raise NotImplementedError
+
+
+class DislikeListSingerSchema(Schema):
+    """
+    不喜欢列表（下称“黑名单”）中的一位歌手。
+    可选字段在 API 返回值中总是提供，但增删列表时无需提供这些字段。
+    """
+    identifier = fields.Str(data_key="ID", required=True)
+    name = fields.Str(data_key="Name", required=True)
+    cover = fields.Str(data_key="Img", required=False)
+    id_type = fields.Int(data_key="IdType", required=True) # 同上
+    add_time = fields.Int(data_key="Time", required=False)
+
+    @post_load
+    def create_model(self, data, **kwargs):
+        raise NotImplementedError

--- a/fuo_qqmusic/schemas.py
+++ b/fuo_qqmusic/schemas.py
@@ -357,34 +357,3 @@ class SearchMVSchema(Schema):
     @post_load
     def create_model(self, data, **kwargs):
         return create_model(VideoModel, data)
-
-class DislikeListSongSchema(Schema):
-    """
-    不喜欢列表（下称“黑名单”）中的一首歌曲。
-    可选字段在 API 返回值中总是提供，但增删列表时无需提供这些字段。
-    """
-    identifier = fields.Str(data_key="ID", required=True)
-    title = fields.Str(data_key="Name", required=True)
-    cover = fields.Str(data_key="Img", required=False)
-    id_type = fields.Int(data_key="IdType", required=True) # 歌曲 identifier 的类型，一般填 0 即可
-    add_time = fields.Int(data_key="Time", required=False)
-
-    @post_load
-    def create_model(self, data, **kwargs):
-        raise NotImplementedError
-
-
-class DislikeListSingerSchema(Schema):
-    """
-    不喜欢列表（下称“黑名单”）中的一位歌手。
-    可选字段在 API 返回值中总是提供，但增删列表时无需提供这些字段。
-    """
-    identifier = fields.Str(data_key="ID", required=True)
-    name = fields.Str(data_key="Name", required=True)
-    cover = fields.Str(data_key="Img", required=False)
-    id_type = fields.Int(data_key="IdType", required=True) # 同上
-    add_time = fields.Int(data_key="Time", required=False)
-
-    @post_load
-    def create_model(self, data, **kwargs):
-        raise NotImplementedError

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     install_requires=[
         'feeluown>=4.1.3',
         'requests',
-        'marshmallow>=3.0'
+        'marshmallow>=3.0,<4.0.0'
     ],
     entry_points={
         'fuo.plugins_v1': [

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -31,10 +31,15 @@ def parse_cookie_to_dict(cookie_str):
 
 cookie_str = "Your cookie string here"
 
+
 @pytest.mark.skip(reason="need valid cookies")
 def test_api():
     api = API()
     api.set_cookies(parse_cookie_to_dict(cookie_str))
+    # You can also use the following code to load cookies
+    # from fuo_qqmusic.provider import provider
+    # provider.auto_login()
+    # api = provider.api
     items = [
         {
             "ID": "238159921",
@@ -42,9 +47,9 @@ def test_api():
             "IdType": 0,
         }
     ]
-    print(api.add_to_dislike_list(items, type=API.DislikeListType.song))
-    print(api.get_dislike_list(type=API.DislikeListType.song))
-    print(api.remove_from_dislike_list(items, type=API.DislikeListType.song))
+    print(api.add_to_dislike_list(items, type_=API.DislikeListType.song))
+    print(api.get_dislike_list(type_=API.DislikeListType.song))
+    print(api.remove_from_dislike_list(items, type_=API.DislikeListType.song))
 
 
 if __name__ == "__main__":

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,50 @@
+from fuo_qqmusic.api import API
+
+
+def parse_cookie_to_dict(cookie_str):
+    # 初始化结果字典
+    result = {}
+
+    # 按分号分割字符串，得到每个键值对
+    pairs = cookie_str.split(";")
+
+    for pair in pairs:
+        # 去除两端空格
+        pair = pair.strip()
+
+        # 按等号分割键和值
+        if "=" in pair:
+            key, value = pair.split("=", 1)
+            key = key.strip()
+            value = value.strip()
+
+            # 如果值为空字符串，则设置为 None
+            if value == "":
+                value = None
+
+            # 存入字典
+            result[key] = value
+
+    return result
+
+
+cookie_str = "Your cookie string here"
+
+
+def test_api():
+    api = API()
+    api.set_cookies(parse_cookie_to_dict(cookie_str))
+    items = [
+        {
+            "ID": "238159921",
+            "Name": "无人区-Vacuum Track#ADD8E6- - 米缐p.",
+            "IdType": 0,
+        }
+    ]
+    print(api.add_to_dislike_list(items, type=API.DislikeListType.song))
+    print(api.get_dislike_list(type=API.DislikeListType.song))
+    print(api.remove_from_dislike_list(items, type=API.DislikeListType.song))
+
+
+if __name__ == "__main__":
+    test_api()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 from fuo_qqmusic.api import API
+import pytest
 
 
 def parse_cookie_to_dict(cookie_str):
@@ -30,7 +31,7 @@ def parse_cookie_to_dict(cookie_str):
 
 cookie_str = "Your cookie string here"
 
-
+@pytest.mark.skip(reason="need valid cookies")
 def test_api():
     api = API()
     api.set_cookies(parse_cookie_to_dict(cookie_str))


### PR DESCRIPTION
该 PR：

1. 引入了对 QQ 音乐「不喜欢列表」（下称「黑名单」）机制的支持，该机制允许用户从推荐歌单和电台中永久屏蔽某些歌手/歌曲。
    相关实现方法为 `get_dislike_list`、`add_to_dislike_list` 和 `remove_from_dislike_list`。用法在 `tests/test_api.py` 中。
2. 限制 `marshmallow` 版本为 `<4.0.0`，以避免与 4.0.0 破坏性更新的不兼容性。
    ⚠️注意：本项目中使用的一些语法已经过时（例如 `missing=` 语法已被删除），建议尽快升级到 marshmallow 4.0.0。

⚠️注意：由于相关新功能需要在 FeelUOwn 主仓库中添加新 API 和 Model，本 PR 中的 `fuo_qqmusic/provider.py` 和 `fuo_qqmusic/schemas.py` 部分实现是不完全的。需要在更新主仓库后再补全相关实现。