### PR TITLE
schemas: fix API changes after marshmallow 3.13.0

### DIFF
--- a/fuo_qqmusic/schemas.py
+++ b/fuo_qqmusic/schemas.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class BaseSchema(Schema):
-    source = fields.Str(missing="qqmusic")
+    source = fields.Str(load_default="qqmusic")
 
     class Meta:
         unknown = EXCLUDE
@@ -94,7 +94,7 @@ class QQSongSchema(Schema):
     artists = fields.List(fields.Nested("_SongArtistSchema"),
                           data_key="singer")
     album = fields.Nested("_SongAlbumSchema", required=True)
-    files = fields.Dict(data_key="file", missing={})
+    files = fields.Dict(data_key="file", load_default={})
     mv = fields.Dict(required=True)
 
     @post_load
@@ -221,9 +221,9 @@ class QQArtistSchema(Schema):
     mid = fields.Str(data_key="singer_mid", required=True)
     name = fields.Str(data_key="singer_name", required=True)
 
-    description = fields.Str(data_key="SingerDesc", missing="")
+    description = fields.Str(data_key="SingerDesc", load_default="")
     hot_songs = fields.List(
-        fields.Nested(_ArtistSongSchema), data_key="list", missing=list
+        fields.Nested(_ArtistSongSchema), data_key="list", load_default=list
     )
 
     @post_load

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     install_requires=[
         'feeluown>=4.1.13',
         'requests',
-        'marshmallow>=3.0,<4.0.0'
+        'marshmallow>=3.13.0,<4.0.0'
     ],
     entry_points={
         'fuo.plugins_v1': [


### PR DESCRIPTION
This will cause the plugin loading to fail because the `missing` parameter is no longer available after this version.

Link to the change for marshmallow: https://github.com/marshmallow-code/marshmallow/commit/1db1a8a8704133d751ec6a4a94b7beb00552413e

feeluown-netease also has this problem, so there is a similar PR at https://github.com/feeluown/feeluown-netease/pull/41